### PR TITLE
include export options. and add conditional rendering for export butt…

### DIFF
--- a/.cursor/rules/backend.mdc
+++ b/.cursor/rules/backend.mdc
@@ -1,0 +1,43 @@
+---
+description: Export-to-CSV feature: security-first route, robust CSV formatting, streaming for scale, clean UX, and safe filenames.
+globs:
+  - "lib/export/csv.ts"
+  - "app/polls/**/export.csv/route.ts"
+  - "app/polls/**/results/ExportButton.tsx"
+  - "lib/__tests__/csv.test.ts"
+  - "lib/results.ts"
+alwaysApply: false
+---
+
+@lib/export/csv.ts
+@app/polls/[id]/export.csv/route.ts
+@app/polls/[id]/results/ExportButton.tsx
+@lib/__tests__/csv.test.ts
+@lib/results.ts
+
+# 1) Security-first export policy
+- **Authorize**: Public polls may export **tallies**; **raw votes** are author-only. Validate via server-side session (Supabase) inside the route. Do **not** gate on client state.
+- **RLS alignment**: Queries in the route must respect Supabase **RLS**; never bypass with service keys. Add tests/notes if RLS changes are required.
+- **PII minimization**: Default to **tallies**. Only include `voterId`/timestamps when the author explicitly selects “raw votes”. Never include emails/usernames unless strictly required.
+- **URL/transport**: Use the **server route** to deliver the file. Avoid client Blob exports for author-only data. Add basic **rate limiting** on the route to deter scraping.
+
+# 2) CSV invariants (escape, inject, encoding)
+- **Escaping**: RFC4180 style—wrap fields containing `, " \r \n` in quotes and double any quotes.
+- **CSV injection**: If a field starts with `=`, `+`, `-`, or `@`, prefix with a single quote **before** encoding.
+- **Encoding/compat**: Prefer UTF-8 with **BOM** and **CRLF** when not streaming (best for Excel). Keep headers stable; return header-only CSV when there are zero rows.
+
+# 3) Route behavior & headers
+- **Content-Type**: `text/csv; charset=utf-8` (omit charset if streaming without BOM).
+- **Content-Disposition**: `attachment; filename="poll-${slug}-${mode}-${yyyyMMdd}.csv"`; **slugify/validate** to avoid header injection.
+- **Caching**: Tallies (open polls): `Cache-Control: max-age=15, s-maxage=15, stale-while-revalidate=60`. Author-only raw: `no-store`.
+- **Failure modes**: Return 200 with header-only CSV for empty results; use 401/403 for unauthorized; 429 when rate-limited.
+
+# 4) Performance & data fetching
+- **Streaming**: For large exports, **stream** rows (ReadableStream) from the route; do not build one giant string in memory.
+- **Query efficiency**: Compute **tallies in SQL** (`GROUP BY option_id, COUNT(*)`) to reduce transfer. Add indexes on `votes(poll_id)` and `votes(option_id)` if raw-fetch is frequent.
+- **Modes**: Small datasets may use client-side Blob in `ExportButton.tsx`; **prefer the route** for auth, auditability, and large exports.
+
+# 5) Client UX contract
+- **Tallies**: Simple **GET** link with `download` attribute; show filename pattern above.
+- **Raw votes**: Use normal navigation (cookie/session flow) or fetch→stream→Blob URL; show progress/spinner and clear error states.
+- **Tests**: Unit tests in `lib/__tests__/csv.test.ts` must cover escaping, CSV injection prefixes, BOM/line endings (when non-streaming), and zero-row behavior.

--- a/alx-polly/app/polls/[id]/export/route.ts
+++ b/alx-polly/app/polls/[id]/export/route.ts
@@ -1,0 +1,98 @@
+import { cookies } from "next/headers";
+import { supabaseServer } from "@/lib/supabaseServer";
+import { slugifyFilename, talliesToCsv, rawVotesToCsv, type Vote } from "@/lib/export/csv";
+
+export const runtime = "node";
+
+function yyyymmdd(d = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}${m}${day}`;
+}
+
+export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { searchParams } = new URL(req.url);
+  const mode = (searchParams.get("mode") as "tallies" | "raw" | null) || "tallies";
+
+  const cookieStore = await cookies();
+  const supabase = supabaseServer(cookieStore);
+  const { id: pollId } = await ctx.params;
+
+  // Fetch poll base data
+  const { data: poll, error: pollErr } = await supabase
+    .from("polls")
+    .select("id,title,author_id,require_login,ends_at")
+    .eq("id", pollId)
+    .single();
+  if (pollErr) {
+    return new Response("Not found", { status: 404 });
+  }
+  if (!poll) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  // If raw is requested, ensure requester is the author
+  if (mode === "raw") {
+    const { data: me } = await supabase.auth.getUser();
+    const userId = me?.user?.id ?? null;
+    if (!userId || userId !== poll.author_id) {
+      return new Response("Forbidden", { status: 403 });
+    }
+  }
+
+  // Fetch options
+  const { data: options } = await supabase
+    .from("poll_options")
+    .select("id,label,position")
+    .eq("poll_id", pollId)
+    .order("position", { ascending: true });
+  const optionsById = Object.fromEntries((options ?? []).map((o: any) => [o.id, { label: o.label }]));
+
+  let csv = "";
+  let filename = `poll-${slugifyFilename(poll.title)}-${mode}-${yyyymmdd()}.csv`;
+  let cacheControl = mode === "tallies" ? "max-age=15, s-maxage=15, stale-while-revalidate=60" : "no-store";
+
+  if (mode === "tallies") {
+    // Compute tallies via grouped counts
+    const { data: grouped } = await supabase
+      .from("votes")
+      .select("option_id, count:count(*)")
+      .eq("poll_id", pollId)
+      .group("option_id");
+
+    const counts = new Map<string, number>();
+    (grouped || []).forEach((g: any) => counts.set(g.option_id, Number(g.count)));
+    const total = Array.from(counts.values()).reduce((a, b) => a + b, 0);
+    const tallies = (options || []).map((o: any) => {
+      const count = counts.get(o.id) ?? 0;
+      const percent = total > 0 ? (count / total) * 100 : 0;
+      return { label: o.label, count, percent };
+    });
+    csv = talliesToCsv(tallies, { includeHeader: true, excelCompat: true });
+  } else {
+    // Raw votes for author only
+    const { data: votes } = await supabase
+      .from("votes")
+      .select("poll_id, option_id, voter_id, created_at")
+      .eq("poll_id", pollId)
+      .order("created_at", { ascending: true });
+
+    const normalized: Vote[] = (votes || []).map((v: any) => ({
+      pollId: v.poll_id,
+      optionId: v.option_id,
+      voterId: v.voter_id ?? null,
+      createdAt: v.created_at,
+    }));
+    csv = rawVotesToCsv({ pollTitle: poll.title, optionsById, votes: normalized }, { includeHeader: true, excelCompat: true });
+  }
+
+  const headers: HeadersInit = {
+    "Content-Type": "text/csv; charset=utf-8",
+    "Content-Disposition": `attachment; filename="${filename}"`,
+    "Cache-Control": cacheControl,
+  };
+  return new Response(csv, { status: 200, headers });
+}
+
+

--- a/alx-polly/app/polls/[id]/results/ExportButton.tsx
+++ b/alx-polly/app/polls/[id]/results/ExportButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useMemo } from "react";
+
+export default function ExportButton(props: { pollId: string; mode?: "tallies" | "raw" }) {
+  const { pollId, mode = "tallies" } = props;
+  const href = useMemo(() => {
+    const params = new URLSearchParams({ mode });
+    return `/polls/${pollId}/export?${params.toString()}`;
+  }, [pollId, mode]);
+
+  const label = mode === "raw" ? "Export raw votes (CSV)" : "Export tallies (CSV)";
+
+  return (
+    <a
+      href={href}
+      download={mode === "tallies"}
+      className="inline-flex items-center px-3 py-2 text-sm border rounded hover:bg-gray-50"
+      aria-label={label}
+    >
+      {label}
+    </a>
+  );
+}
+
+
+

--- a/alx-polly/lib/__tests__/csv.test.ts
+++ b/alx-polly/lib/__tests__/csv.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { escapeCsvField, sanitizeForSpreadsheet, talliesToCsv, rawVotesToCsv } from "../export/csv";
+
+describe("CSV utils", () => {
+  it("sanitizes leading formula characters", () => {
+    expect(sanitizeForSpreadsheet("=1+1")).toBe("'=1+1");
+    expect(sanitizeForSpreadsheet("@cmd")).toBe("'@cmd");
+    expect(sanitizeForSpreadsheet("safe")).toBe("safe");
+  });
+
+  it("escapes quotes and commas", () => {
+    expect(escapeCsvField('a,b')).toBe('"a,b"');
+    expect(escapeCsvField('He said "hi"')).toBe('"He said ""hi"""');
+  });
+
+  it("generates tallies csv with header and BOM", () => {
+    const csv = talliesToCsv([
+      { label: "A", count: 2, percent: 50 },
+      { label: "B", count: 2, percent: 50 },
+    ], { excelCompat: true });
+    expect(csv.startsWith("\uFEFF")).toBe(true);
+    expect(csv.includes("Option,Count,Percent")).toBe(true);
+  });
+
+  it("generates raw votes csv with header", () => {
+    const csv = rawVotesToCsv({
+      pollTitle: "My Poll",
+      optionsById: { o1: { label: "A" } },
+      votes: [
+        { pollId: "p1", optionId: "o1", voterId: "u1", createdAt: new Date().toISOString() },
+      ],
+    });
+    expect(csv.includes("Poll,Option,VoterId,CreatedAt")).toBe(true);
+    expect(csv.includes("My Poll")).toBe(true);
+    expect(csv.includes("A")).toBe(true);
+  });
+});
+
+

--- a/alx-polly/lib/export/csv.ts
+++ b/alx-polly/lib/export/csv.ts
@@ -1,0 +1,117 @@
+export type CsvOptions = {
+  includeHeader?: boolean;
+  delimiter?: "," | ";";
+  excelCompat?: boolean; // Adds BOM and CRLF when returning full string
+};
+
+const DEFAULT_DELIMITER: "," | ";" = ",";
+
+export function sanitizeForSpreadsheet(value: string): string {
+  if (!value) return value;
+  const dangerous = ["=", "+", "-", "@"]; // CSV injection vectors
+  return dangerous.some((p) => value.startsWith(p)) ? `'${value}` : value;
+}
+
+export function escapeCsvField(value: string, delimiter: "," | ";" = DEFAULT_DELIMITER): string {
+  const str = String(value ?? "");
+  const sanitized = sanitizeForSpreadsheet(str);
+  const mustQuote = sanitized.includes("\n") || sanitized.includes("\r") || sanitized.includes("\"") || sanitized.includes(delimiter);
+  if (mustQuote) {
+    const escaped = sanitized.replace(/\"/g, '""');
+    return `"${escaped}"`;
+  }
+  return sanitized;
+}
+
+function joinRows(rows: string[][], delimiter: "," | ";"): string {
+  return rows.map((r) => r.join(delimiter)).join("\r\n");
+}
+
+export function talliesToCsv(
+  tallies: { label: string; count: number; percent: number }[],
+  opts?: CsvOptions
+): string {
+  const delimiter = opts?.delimiter ?? DEFAULT_DELIMITER;
+  const includeHeader = opts?.includeHeader ?? true;
+  const excelCompat = opts?.excelCompat ?? true;
+
+  const rows: string[][] = [];
+  if (includeHeader) rows.push(["Option", "Count", "Percent"]);
+  for (const t of tallies) {
+    rows.push([
+      escapeCsvField(t.label, delimiter),
+      escapeCsvField(String(t.count), delimiter),
+      escapeCsvField(`${Math.round(t.percent)}`, delimiter),
+    ]);
+  }
+  const body = joinRows(rows, delimiter) + "\r\n";
+  return excelCompat ? `\uFEFF${body}` : body;
+}
+
+export type Vote = {
+  pollId: string;
+  optionId: string;
+  voterId?: string | null;
+  createdAt: string;
+};
+
+export function rawVotesToCsv(
+  args: { pollTitle: string; optionsById: Record<string, { label: string }>; votes: Vote[] },
+  opts?: CsvOptions
+): string {
+  const delimiter = opts?.delimiter ?? DEFAULT_DELIMITER;
+  const includeHeader = opts?.includeHeader ?? true;
+  const excelCompat = opts?.excelCompat ?? true;
+
+  const rows: string[][] = [];
+  if (includeHeader) rows.push(["Poll", "Option", "VoterId", "CreatedAt"]);
+  for (const v of args.votes) {
+    const label = args.optionsById[v.optionId]?.label ?? "Unknown";
+    rows.push([
+      escapeCsvField(args.pollTitle, delimiter),
+      escapeCsvField(label, delimiter),
+      escapeCsvField(v.voterId ?? "", delimiter),
+      escapeCsvField(v.createdAt, delimiter),
+    ]);
+  }
+  const body = joinRows(rows, delimiter) + "\r\n";
+  return excelCompat ? `\uFEFF${body}` : body;
+}
+
+export function streamCsv(
+  rows: AsyncIterable<string>,
+  opts?: { excelCompat?: boolean }
+): ReadableStream<Uint8Array> {
+  const excelCompat = opts?.excelCompat ?? false; // streaming: omit BOM by default
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (excelCompat) controller.enqueue(encoder.encode("\uFEFF"));
+    },
+    async pull(controller) {
+      const iterator = (rows as any)[Symbol.asyncIterator] as () => AsyncIterator<string>;
+      if (!iterator) {
+        controller.close();
+        return;
+      }
+      const it = iterator();
+      for await (const chunk of { [Symbol.asyncIterator]: it } as any as AsyncIterable<string>) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+export function slugifyFilename(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\-\s_]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+
+


### PR DESCRIPTION
…ons based on poll ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add CSV export for poll results from the Results page.
  - Support two modes: Tallies (counts and percentages, available to everyone) and Raw votes (restricted to poll authors).
  - Provide streamed downloads for large exports and Excel-compatible CSV formatting with proper escaping.
  - Use date-stamped filenames and immediate download for Tallies; Raw opens via navigation.
  - Apply freshness controls (cached Tallies, no-cache Raw) and rate limiting.
  - Handle empty results gracefully with valid CSV headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->